### PR TITLE
解决错误信息弹窗卡死问题

### DIFF
--- a/STATUS/StartClient.py
+++ b/STATUS/StartClient.py
@@ -278,7 +278,7 @@ class Stats:
         except Exception as e:
             self.ui.serverLbl.setStyleSheet("color: rgb(255, 255, 255); background-color: rgba(255, 0, 0, 200);")
             self.ui.serverLbl.setText('远程目录列表（连接失败！）：')
-            self.exception = str(e)  # e的类型时error，要转成string显示
+            self.exception = str(e) # e的类型是error，要转成string显示
             self.msgthread.start()
 
     def change_dir(self):


### PR DESCRIPTION
MessageBox只能在主线程中弹出，在子线程中调用就会卡死。故弹窗函数应当放在主线程，子线程只负责告诉主线程是否要弹窗（使用pyqtsignal）。

下面使用`x= 1/0`抛出`division by zero`作为例子。

![image](https://user-images.githubusercontent.com/87693204/200731019-5340d32c-6b4d-48fc-966e-e7fbd7416415.png)
